### PR TITLE
fix: show completions for keywords, not index

### DIFF
--- a/src/codemirror/python.js
+++ b/src/codemirror/python.js
@@ -17,7 +17,7 @@ function makeCompletions(builtins, type, boost, info) {
   const completions = []
   for (const k in builtins) {
     completions.push(
-      snippetCompletion(k, {
+      snippetCompletion(Array.isArray(builtins) ? builtins[k] : k, {
         label: Array.isArray(builtins) ? builtins[k] : k,
         type: type,
         info: info ? builtins[k] : '',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR correctly shows completions for keywords, not index

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
